### PR TITLE
Feature/issue2

### DIFF
--- a/src/VisualiseTracab.hs
+++ b/src/VisualiseTracab.hs
@@ -7,8 +7,9 @@ import System.Environment (getArgs)
 main :: IO ()
 main
  =  do
-    (filename : clArguments) <- getArgs
-    frames <- Tracab.parseDataFile filename
+    (metafile : datafile : clArguments) <- getArgs
+    meta <- Tracab.parseMetaFile metafile
+    frames <- Tracab.parseDataFile meta datafile
     animate (InWindow "Tracab" (800, 600) (5,5)) (greyN 0.2) (frame frames)
 
 frame :: Tracab.Frames -> Float -> Picture


### PR DESCRIPTION
This is a basic implied clock for Tracab frames, implemented as `Maybe Double`, in seconds from period start (since we'll be aligning by periods anyway), with `Nothing` if the frame does not belong to any period.

Parsed metadata is now an argument to the datafile parsing function, something that should be handy for #1 as well, since it contains pitch dimensions.

Feel free to merge if/when you are happy with it.